### PR TITLE
security(backend): route testnet explorer through ryo-currency.com

### DIFF
--- a/src-electron/main-process/modules/backend.js
+++ b/src-electron/main-process/modules/backend.js
@@ -207,7 +207,7 @@ export class Backend {
             case "open_explorer":
                 let explorer_url = "https://explorer.ryo-currency.com"
                 if(this.config_data.app.testnet) {
-                    explorer_url = "https://tnexp.ryoblocks.com"
+                    explorer_url = "https://tnexp.ryo-currency.com"
                 }
                 if(params.type == "tx") {
                     require("electron").shell.openExternal(`${explorer_url}/tx/${params.id}`)


### PR DESCRIPTION
## Context

Following the private security report sent to `contact@ryo-currency.com` on 2026-08-09 (and the team's reply of 2026-08-10 asking me to submit Pull Requests).

Companion PR: [`ryo-currency/ryo-currency#323`](https://github.com/ryo-currency/ryo-currency/pull/323).

## Problem

`src-electron/main-process/modules/backend.js:210` hardcodes the testnet explorer URL to `https://tnexp.ryoblocks.com`.

The `ryoblocks.com` domain is **no longer registered to the Ryo Currency project**. `whois` shows it was re-registered under `DYNADOT LLC` on `2024-08-27` (Ryo's other domains are registered under `NAMECHEAP INC`). Its apex currently serves an unrelated Russian used-car page (`WordPress` + `PHP/7.4.33`). Any subdomain, including `tnexp.`, can be pointed at attacker-controlled content by the current owner at any time.

## Impact

When a user browsing testnet clicks the "Explorer" button on a transaction or block, `Backend#dispatch("open_explorer", ...)` calls:

```js
require("electron").shell.openExternal(`${explorer_url}/tx/${params.id}`)
```

with `explorer_url = "https://tnexp.ryoblocks.com"`. Attacker-served content at that URL runs in the user's default browser under a session that likely contains other wallet-related cookies or credentials, and can trivially phish testnet-adjacent credentials or drop wallet-download-style malware links.

Scope is testnet only, so mainnet funds are not directly at risk, but users often reuse the same host, browser, and passphrase habits across testnet and mainnet.

## Fix

Route the testnet explorer through the project-owned `tnexp.ryo-currency.com`, parallel to the mainnet `explorer.ryo-currency.com` already used two lines above and matching the convention `pool.js` already follows:

```console
$ grep -n 'ryo-currency\.com\|ryoblocks' src-electron/main-process/modules/backend.js src-electron/main-process/modules/pool.js
src-electron/main-process/modules/backend.js:208: explorer_url = "https://explorer.ryo-currency.com"
src-electron/main-process/modules/backend.js:210: explorer_url = "https://tnexp.ryo-currency.com"     # <-- fixed
src-electron/main-process/modules/pool.js:193:   url = "https://explorer.ryo-currency.com/api/networkinfo"
src-electron/main-process/modules/pool.js:195:   url = "https://tnexp.ryo-currency.com/api/networkinfo"
```

No functional or UI change. If `tnexp.ryo-currency.com` is not yet in DNS, the ops team can add it (parallel to the existing `explorer.` and `tnexp.ryo-currency.com` used by `pool.js`) before or immediately after merge.

## Verification

```console
$ grep -rEn 'ryoblocks|ryowebwallet' src-electron/
# no matches
```

## Also worth doing (out of scope of this PR)

- Attempt drop-catch on `ryoblocks.com` (expires `2026-08-27`) and `ryowebwallet.com` (expires `2027-03-16`) via a specialist registrar backorder.
- Consider centralising `explorer.` / `tnexp.` hosts into a small constants module so future rebrands touch one file.